### PR TITLE
Add initial Inskin application skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Inskin
+
+Prototype application for managing NFC/RFID badges and implants.
+
+This repository provides a minimal placeholder implementation written in Python.
+It demonstrates how the future Inskin project could structure its code.
+
+## Features
+- Read a mock tag and display its data.
+- Write mock data to a tag (currently prints to console).
+- Simple unit test verifying the read functionality.
+
+## Usage
+```bash
+python main.py
+```
+
+## Testing
+```bash
+python -m pytest
+```

--- a/inskin/__init__.py
+++ b/inskin/__init__.py
@@ -1,0 +1,10 @@
+"""
+Inskin core module.
+
+Provides basic placeholder functions to read and write NFC/RFID tags.
+"""
+
+from .reader import read_tag
+from .writer import write_tag
+
+__all__ = ["read_tag", "write_tag"]

--- a/inskin/reader.py
+++ b/inskin/reader.py
@@ -1,0 +1,8 @@
+"""Reader utilities for Inskin.
+
+These functions are placeholders for actual NFC/RFID reader interactions.
+"""
+
+def read_tag():
+    """Return mock data representing a scanned tag."""
+    return {"uid": "DEADBEEF", "type": "placeholder"}

--- a/inskin/writer.py
+++ b/inskin/writer.py
@@ -1,0 +1,8 @@
+"""Writer utilities for Inskin.
+
+These functions are placeholders for actual NFC/RFID writer interactions.
+"""
+
+def write_tag(data):
+    """Mock writing data to a tag by printing the payload."""
+    print(f"Writing data to tag: {data}")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+"""Command-line interface for the Inskin placeholder application."""
+
+from inskin import read_tag, write_tag
+
+
+def main():
+    """Demonstrate reading and writing tag operations."""
+    tag = read_tag()
+    print("Read tag:", tag)
+    write_tag({"text": "Hello from Inskin"})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,6 @@
+from inskin import read_tag
+
+
+def test_read_tag_returns_mock_data():
+    tag = read_tag()
+    assert tag["uid"] == "DEADBEEF"


### PR DESCRIPTION
## Summary
- scaffold basic Python project for Inskin
- add placeholder tag reader and writer utilities
- include simple CLI and test

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e71d78d88323a2b12957b3afaeb5