### PR TITLE
Add Android NFC reader/writer sample

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+  id("com.android.application")
+  id("org.jetbrains.kotlin.android")
+}
+
+android {
+  namespace = "com.inskin.app"
+  compileSdk = 35
+
+  defaultConfig {
+    applicationId = "com.inskin.app"
+    minSdk = 24
+    targetSdk = 35
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+
+  buildFeatures { compose = true }
+  composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+}
+
+dependencies {
+  implementation(platform("androidx.compose:compose-bom:2024.10.01"))
+  implementation("androidx.activity:activity-compose:1.9.2")
+  implementation("androidx.compose.ui:ui")
+  implementation("androidx.compose.material3:material3:1.3.0")
+  implementation("androidx.navigation:navigation-compose:2.8.0")
+  implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.5")
+}

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-feature android:name="android.hardware.nfc" android:required="false"/>
+  <uses-permission android:name="android.permission.NFC"/>
+
+  <application android:label="@string/app_name" android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+    <activity android:name=".MainActivity" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+
+      <!-- Optionnel: réveille l’app sur tags NDEF -->
+      <intent-filter>
+        <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:mimeType="text/plain"/>
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:scheme="http"/>
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:scheme="https"/>
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/android-app/app/src/main/java/com/inskin/app/MainActivity.kt
+++ b/android-app/app/src/main/java/com/inskin/app/MainActivity.kt
@@ -1,0 +1,29 @@
+package com.inskin.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
+import com.inskin.app.nav.InskinNav
+import com.inskin.app.nfc.NfcController
+
+class MainActivity : ComponentActivity() {
+  private lateinit var nfc: NfcController
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    nfc = NfcController(this)
+
+    setContent { InskinNav(nfc = nfc) }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    nfc.enableReaderMode()
+  }
+  override fun onPause() {
+    nfc.disableReaderMode()
+    super.onPause()
+  }
+}

--- a/android-app/app/src/main/java/com/inskin/app/nav/Nav.kt
+++ b/android-app/app/src/main/java/com/inskin/app/nav/Nav.kt
@@ -1,0 +1,40 @@
+package com.inskin.app.nav
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.*
+import com.inskin.app.nfc.NfcController
+import com.inskin.app.ui.ReadScreen
+import com.inskin.app.ui.WriteScreen
+
+@Composable
+fun InskinNav(nfc: NfcController) {
+  val nav = rememberNavController()
+  Scaffold(
+    bottomBar = {
+      NavigationBar {
+        NavigationBarItem(selected = currentRoute(nav)=="read",
+          onClick = { nav.navigate("read"){ launchSingleTop=true } },
+          label = { Text("Lecture") }, icon = { Icon(Icons.Filled.Info, null) })
+        NavigationBarItem(selected = currentRoute(nav)=="write",
+          onClick = { nav.navigate("write"){ launchSingleTop=true } },
+          label = { Text("Écriture") }, icon = { Icon(Icons.Filled.Edit, null) })
+      }
+    }
+  ){ padding ->
+    NavHost(nav, "read", Modifier.padding(padding).fillMaxSize()) {
+      composable("read"){ ReadScreen(nfc) }
+      composable("write"){ WriteScreen(nfc) }
+    }
+  }
+}
+
+@Composable
+private fun currentRoute(nav: NavHostController): String? =
+  nav.currentBackStackEntryFlow.collectAsState(initial = nav.currentBackStackEntry).value?.destination?.route

--- a/android-app/app/src/main/java/com/inskin/app/nfc/NdefUtils.kt
+++ b/android-app/app/src/main/java/com/inskin/app/nfc/NdefUtils.kt
@@ -1,0 +1,66 @@
+package com.inskin.app.nfc
+
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import java.nio.charset.Charset
+import java.util.Locale
+
+object NdefUtils {
+  data class NdefParsed(val type: String, val value: String)
+  data class NdefBuild(val records: List<NdefRecord>)
+
+  fun parse(msg: NdefMessage?): List<NdefParsed> {
+    if (msg == null) return emptyList()
+    return msg.records.mapNotNull { rec ->
+      when {
+        rec.tnf == NdefRecord.TNF_WELL_KNOWN && rec.type.contentEquals(NdefRecord.RTD_TEXT) ->
+          NdefParsed("text", decodeText(rec))
+        rec.tnf == NdefRecord.TNF_WELL_KNOWN && rec.type.contentEquals(NdefRecord.RTD_URI) ->
+          NdefParsed("uri", decodeUri(rec))
+        else -> NdefParsed("raw", rec.payload.joinToString("") { "%02X".format(it) })
+      }
+    }
+  }
+
+  fun build(build: NdefBuild): NdefMessage = NdefMessage(build.records.toTypedArray())
+
+  fun textRecord(text: String, locale: Locale = Locale.getDefault()): NdefRecord {
+    val langBytes = locale.language.toByteArray(Charsets.US_ASCII)
+    val textBytes = text.toByteArray(Charsets.UTF_8)
+    val payload = ByteArray(1 + langBytes.size + textBytes.size)
+    payload[0] = langBytes.size.toByte()
+    System.arraycopy(langBytes, 0, payload, 1, langBytes.size)
+    System.arraycopy(textBytes, 0, payload, 1 + langBytes.size, textBytes.size)
+    return NdefRecord(NdefRecord.TNF_WELL_KNOWN, NdefRecord.RTD_TEXT, ByteArray(0), payload)
+  }
+
+  fun uriRecord(uri: String): NdefRecord {
+    val prefixMap = listOf(
+      "", "http://www.", "https://www.", "http://", "https://"
+    )
+    val match = prefixMap.withIndex().maxByOrNull { if (uri.startsWith(it.value)) it.value.length else -1 }!!
+    val prefixCode = match.index.toByte()
+    val rest = uri.removePrefix(match.value).toByteArray(Charset.forName("UTF-8"))
+    val payload = ByteArray(1 + rest.size)
+    payload[0] = prefixCode
+    System.arraycopy(rest, 0, payload, 1, rest.size)
+    return NdefRecord(NdefRecord.TNF_WELL_KNOWN, NdefRecord.RTD_URI, ByteArray(0), payload)
+  }
+
+  private fun decodeText(record: NdefRecord): String {
+    val payload = record.payload
+    val langLen = payload[0].toInt() and 0x3F
+    val textBytes = payload.copyOfRange(1 + langLen, payload.size)
+    return String(textBytes, Charsets.UTF_8)
+  }
+
+  private fun decodeUri(record: NdefRecord): String {
+    val prefixMap = arrayOf(
+      "", "http://www.", "https://www.", "http://", "https://"
+    )
+    val payload = record.payload
+    val prefix = prefixMap.getOrElse(payload[0].toInt()) { "" }
+    val rest = String(payload.copyOfRange(1, payload.size), Charsets.UTF_8)
+    return prefix + rest
+  }
+}

--- a/android-app/app/src/main/java/com/inskin/app/nfc/NfcController.kt
+++ b/android-app/app/src/main/java/com/inskin/app/nfc/NfcController.kt
@@ -1,0 +1,68 @@
+package com.inskin.app.nfc
+
+import android.app.Activity
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import android.os.Bundle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class NfcController(private val activity: Activity) {
+  private val adapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
+
+  private val _lastRead = MutableStateFlow<NdefResult?>(null)
+  val lastRead = _lastRead.asStateFlow()
+
+  private val _status = MutableStateFlow(Status())
+  val status = _status.asStateFlow()
+
+  private val _lastTag = MutableStateFlow<Tag?>(null)
+  val lastTag = _lastTag.asStateFlow()
+
+  data class Status(val nfcAvailable: Boolean = true, val readerEnabled: Boolean = false)
+  data class NdefResult(val uid: String, val tech: List<String>, val records: List<NdefUtils.NdefParsed>)
+
+  fun enableReaderMode() {
+    if (adapter == null) { _status.value = Status(nfcAvailable=false); return }
+    val flags = NfcAdapter.FLAG_READER_NFC_A or NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_NFC_F or NfcAdapter.FLAG_READER_NFC_V or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+    adapter.enableReaderMode(activity, { tag -> onTag(tag) }, flags, Bundle())
+    _status.value = Status(nfcAvailable=true, readerEnabled=true)
+  }
+
+  fun disableReaderMode() {
+    adapter?.disableReaderMode(activity)
+    _status.value = _status.value.copy(readerEnabled=false)
+  }
+
+  private fun onTag(tag: Tag) {
+    val uid = tag.id?.joinToString("") { "%02X".format(it) } ?: "UNKNOWN"
+    val techs = tag.techList.toList()
+    val ndef = Ndef.get(tag)
+    val parsed = try {
+      val msg = ndef?.cachedNdefMessage ?: run {
+        ndef?.connect()
+        val m = ndef?.ndefMessage
+        ndef?.close()
+        m
+      }
+      NdefUtils.parse(msg)
+    } catch (_: Exception) { emptyList() }
+    _lastTag.value = tag
+    _lastRead.value = NdefResult(uid, techs, parsed)
+  }
+
+  /** Écrit une charge NDEF complète sur le tag courant. Retourne null si ok ou message d’erreur. */
+  fun writeNdef(tag: Tag, payload: NdefUtils.NdefBuild): String? = try {
+    val ndef = Ndef.get(tag) ?: return "Tag non NDEF"
+    ndef.connect()
+    val msg = NdefUtils.build(payload)
+    if (!ndef.isWritable) return "Tag en lecture seule"
+    if (ndef.maxSize < msg.toByteArray().size) return "Payload trop grand pour ce tag"
+    ndef.writeNdefMessage(msg)
+    ndef.close()
+    null
+  } catch (e: Exception) { e.message ?: "Écriture échouée" }
+}

--- a/android-app/app/src/main/java/com/inskin/app/ui/ReadScreen.kt
+++ b/android-app/app/src/main/java/com/inskin/app/ui/ReadScreen.kt
@@ -1,0 +1,34 @@
+package com.inskin.app.ui
+
+import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.inskin.app.nfc.NfcController
+
+@Composable
+fun ReadScreen(nfc: NfcController) {
+  val status by nfc.status.collectAsState()
+  val last by nfc.lastRead.collectAsState()
+
+  Column(Modifier.fillMaxSize().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Text("Lecture NFC", style = MaterialTheme.typography.headlineSmall)
+    AssistChip(onClick = {}, label = { Text(if (status.readerEnabled) "Lecture continue active" else "Lecture inactive") })
+    if (!status.nfcAvailable) Text("NFC non disponible sur cet appareil.")
+
+    if (last == null) {
+      Text("Approchez un badge ou implant pour lire…")
+    } else {
+      Card {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+          Text("UID: ${last!!.uid}")
+          Text("Tech: ${last!!.tech.joinToString()}")
+          last!!.records.forEachIndexed { i, r ->
+            Text("[$i] ${r.type.uppercase()}: ${r.value}")
+          }
+        }
+      }
+    }
+  }
+}

--- a/android-app/app/src/main/java/com/inskin/app/ui/WriteScreen.kt
+++ b/android-app/app/src/main/java/com/inskin/app/ui/WriteScreen.kt
@@ -1,0 +1,48 @@
+package com.inskin.app.ui
+
+import android.nfc.Tag
+import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.inskin.app.nfc.NfcController
+import com.inskin.app.nfc.NdefUtils
+
+@Composable
+fun WriteScreen(nfc: NfcController) {
+  var mode by remember { mutableStateOf("TEXT") }
+  var input by remember { mutableStateOf("") }
+  var info by remember { mutableStateOf<String?>(null) }
+  val lastTag by nfc.lastTag.collectAsState()
+  var armed by remember { mutableStateOf(false) }
+
+  Column(Modifier.fillMaxSize().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Text("Écriture NFC", style = MaterialTheme.typography.headlineSmall)
+
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      FilterChip(selected = mode=="TEXT", onClick = { mode="TEXT" }, label = { Text("Texte") })
+      FilterChip(selected = mode=="URI",  onClick = { mode="URI"  }, label = { Text("URL") })
+    }
+
+    OutlinedTextField(value = input, onValueChange = { input = it },
+      label = { Text(if (mode=="TEXT") "Texte à écrire" else "URL à écrire") },
+      modifier = Modifier.fillMaxWidth())
+
+    Text("Approchez un tag pour écrire. L’écriture remplace le contenu NDEF.")
+    Button(onClick = { armed = true; info = "Armez: scannez un tag pour écrire." }) {
+      Text("Armer l’écriture")
+    }
+
+    info?.let { Text(it) }
+  }
+
+  LaunchedEffect(lastTag, armed, mode, input) {
+    val tag = lastTag ?: return@LaunchedEffect
+    if (!armed) return@LaunchedEffect
+    val record = if (mode=="TEXT") NdefUtils.textRecord(input) else NdefUtils.uriRecord(input)
+    val err = nfc.writeNdef(tag, NdefUtils.NdefBuild(listOf(record)))
+    info = err ?: "Écriture réussie."
+    armed = false
+  }
+}

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">Inskin</string>
+</resources>

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+  id("com.android.application") version "8.5.2" apply false
+  id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+}

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+  repositories { google(); mavenCentral(); gradlePluginPortal() }
+}
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories { google(); mavenCentral() }
+}
+rootProject.name = "Inskin"
+include(":app")


### PR DESCRIPTION
## Summary
- Add Android Compose project with reader and writer screens
- Expose last NFC tag in `NfcController`
- Wire write screen to write NDEF text or URI on scanned tag

## Testing
- `PYTHONPATH=. pytest -q`
- `cd android-app && ./gradlew tasks` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e9c906288323a1946f37b7d4f3a0