### PR TITLE
Add NDEF utilities and Gradle configuration

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")
   id("org.jetbrains.kotlin.plugin.compose")
+  id("com.google.devtools.ksp")
 }
 
 android {
@@ -19,21 +20,45 @@ android {
   buildFeatures { compose = true }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
+  }
+
+  signingConfigs {
+    // configured via environment variables
+  }
+
+  buildTypes {
+    release {
+      isMinifyEnabled = true
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+    }
   }
 }
 
 dependencies {
   implementation(platform("androidx.compose:compose-bom:2024.10.01"))
+  implementation("androidx.core:core-ktx:1.13.1")
   implementation("androidx.activity:activity-compose:1.9.2")
   implementation("androidx.compose.ui:ui")
   implementation("androidx.compose.material3:material3:1.3.0")
   implementation("androidx.navigation:navigation-compose:2.8.0")
   implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.5")
-  implementation("com.google.android.material:material:1.12.0")
+  implementation("androidx.compose.material:material-icons-extended:1.6.8")
+
+  // Room + KSP
+  implementation("androidx.room:room-ktx:2.6.1")
+  ksp("androidx.room:room-compiler:2.6.1")
+
+  // DataStore
+  implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+  // Serialization for export JSON
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2")
+
+  testImplementation("junit:junit:4.13.2")
 }

--- a/android-app/app/src/main/java/com/inskin/app/nfc/NdefUtils.kt
+++ b/android-app/app/src/main/java/com/inskin/app/nfc/NdefUtils.kt
@@ -1,66 +1,87 @@
 package com.inskin.app.nfc
 
+import android.net.Uri
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import java.nio.charset.Charset
 import java.util.Locale
 
+/** Utility helpers for building and parsing NDEF records. */
 object NdefUtils {
-  data class NdefParsed(val type: String, val value: String)
-  data class NdefBuild(val records: List<NdefRecord>)
+    data class ParsedRecord(val type: String, val payload: String)
 
-  fun parse(msg: NdefMessage?): List<NdefParsed> {
-    if (msg == null) return emptyList()
-    return msg.records.mapNotNull { rec ->
-      when {
-        rec.tnf == NdefRecord.TNF_WELL_KNOWN && rec.type.contentEquals(NdefRecord.RTD_TEXT) ->
-          NdefParsed("text", decodeText(rec))
-        rec.tnf == NdefRecord.TNF_WELL_KNOWN && rec.type.contentEquals(NdefRecord.RTD_URI) ->
-          NdefParsed("uri", decodeUri(rec))
-        else -> NdefParsed("raw", rec.payload.joinToString("") { "%02X".format(it) })
-      }
+    fun textRecord(text: String, locale: Locale = Locale.getDefault()): NdefRecord {
+        val langBytes = locale.language.encodeToByteArray()
+        val textBytes = text.encodeToByteArray()
+        val payload = ByteArray(1 + langBytes.size + textBytes.size)
+        payload[0] = langBytes.size.toByte()
+        System.arraycopy(langBytes, 0, payload, 1, langBytes.size)
+        System.arraycopy(textBytes, 0, payload, 1 + langBytes.size, textBytes.size)
+        return NdefRecord(
+            NdefRecord.TNF_WELL_KNOWN,
+            NdefRecord.RTD_TEXT,
+            ByteArray(0),
+            payload
+        )
     }
-  }
 
-  fun build(build: NdefBuild): NdefMessage = NdefMessage(build.records.toTypedArray())
+    fun uriRecord(uri: String): NdefRecord = NdefRecord.createUri(uri)
 
-  fun textRecord(text: String, locale: Locale = Locale.getDefault()): NdefRecord {
-    val langBytes = locale.language.toByteArray(Charsets.US_ASCII)
-    val textBytes = text.toByteArray(Charsets.UTF_8)
-    val payload = ByteArray(1 + langBytes.size + textBytes.size)
-    payload[0] = langBytes.size.toByte()
-    System.arraycopy(langBytes, 0, payload, 1, langBytes.size)
-    System.arraycopy(textBytes, 0, payload, 1 + langBytes.size, textBytes.size)
-    return NdefRecord(NdefRecord.TNF_WELL_KNOWN, NdefRecord.RTD_TEXT, ByteArray(0), payload)
-  }
+    fun telRecord(number: String): NdefRecord = uriRecord("tel:$number")
 
-  fun uriRecord(uri: String): NdefRecord {
-    val prefixMap = listOf(
-      "", "http://www.", "https://www.", "http://", "https://"
-    )
-    val match = prefixMap.withIndex().maxByOrNull { if (uri.startsWith(it.value)) it.value.length else -1 }!!
-    val prefixCode = match.index.toByte()
-    val rest = uri.removePrefix(match.value).toByteArray(Charset.forName("UTF-8"))
-    val payload = ByteArray(1 + rest.size)
-    payload[0] = prefixCode
-    System.arraycopy(rest, 0, payload, 1, rest.size)
-    return NdefRecord(NdefRecord.TNF_WELL_KNOWN, NdefRecord.RTD_URI, ByteArray(0), payload)
-  }
+    fun smsRecord(number: String, body: String? = null): NdefRecord {
+        val uri = if (body.isNullOrEmpty()) "sms:$number" else "sms:$number?body=" + Uri.encode(body)
+        return uriRecord(uri)
+    }
 
-  private fun decodeText(record: NdefRecord): String {
-    val payload = record.payload
-    val langLen = payload[0].toInt() and 0x3F
-    val textBytes = payload.copyOfRange(1 + langLen, payload.size)
-    return String(textBytes, Charsets.UTF_8)
-  }
+    fun mailRecord(address: String, subject: String? = null, body: String? = null): NdefRecord {
+        val params = mutableListOf<String>()
+        if (!subject.isNullOrEmpty()) params += "subject=" + Uri.encode(subject)
+        if (!body.isNullOrEmpty()) params += "body=" + Uri.encode(body)
+        val query = if (params.isEmpty()) "" else "?" + params.joinToString("&")
+        return uriRecord("mailto:$address$query")
+    }
 
-  private fun decodeUri(record: NdefRecord): String {
-    val prefixMap = arrayOf(
-      "", "http://www.", "https://www.", "http://", "https://"
-    )
-    val payload = record.payload
-    val prefix = prefixMap.getOrElse(payload[0].toInt()) { "" }
-    val rest = String(payload.copyOfRange(1, payload.size), Charsets.UTF_8)
-    return prefix + rest
-  }
+    fun geoRecord(lat: Double, lon: Double): NdefRecord = uriRecord("geo:$lat,$lon")
+
+    fun vcardRecord(vcard: String): NdefRecord =
+        NdefRecord.createMime("text/vcard", vcard.toByteArray(Charset.forName("UTF-8")))
+
+    fun rawRecord(payload: ByteArray, tnf: Short, type: ByteArray, id: ByteArray? = null): NdefRecord =
+        NdefRecord(tnf, type, id ?: ByteArray(0), payload)
+
+    fun parse(record: NdefRecord): ParsedRecord {
+        if (record.tnf == NdefRecord.TNF_WELL_KNOWN && record.type.contentEquals(NdefRecord.RTD_TEXT)) {
+            val status = record.payload[0].toInt()
+            val langLength = status and 0x3F
+            val text = record.payload.copyOfRange(1 + langLength, record.payload.size).toString(Charset.forName("UTF-8"))
+            return ParsedRecord("TEXT", text)
+        }
+        record.toUri()?.let { uri ->
+            val value = uri.toString()
+            val type = when {
+                value.startsWith("tel:") -> "TEL"
+                value.startsWith("sms:") -> "SMS"
+                value.startsWith("mailto:") -> "MAILTO"
+                value.startsWith("geo:") -> "GEO"
+                else -> "URI"
+            }
+            val payload = when (type) {
+                "TEL" -> value.removePrefix("tel:")
+                "SMS" -> value.removePrefix("sms:")
+                "MAILTO" -> value.removePrefix("mailto:")
+                "GEO" -> value.removePrefix("geo:")
+                else -> value
+            }
+            return ParsedRecord(type, payload)
+        }
+        if (record.tnf == NdefRecord.TNF_MIME_MEDIA && String(record.type) == "text/vcard") {
+            return ParsedRecord("VCARD", record.payload.toString(Charset.forName("UTF-8")))
+        }
+        val hex = record.payload.joinToString(separator = "") { String.format("%02X", it) }
+        return ParsedRecord("RAW", hex)
+    }
+
+    fun estimateSize(records: List<NdefRecord>): Int =
+        NdefMessage(records.toTypedArray()).toByteArray().size
 }

--- a/android-app/app/src/test/java/com/inskin/app/nfc/NdefUtilsTest.kt
+++ b/android-app/app/src/test/java/com/inskin/app/nfc/NdefUtilsTest.kt
@@ -1,0 +1,45 @@
+package com.inskin.app.nfc
+
+import android.nfc.NdefMessage
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NdefUtilsTest {
+    @Test
+    fun `build and parse text`() {
+        val text = "Hello"
+        val record = NdefUtils.textRecord(text)
+        val parsed = NdefUtils.parse(record)
+        assertEquals("TEXT", parsed.type)
+        assertEquals(text, parsed.payload)
+    }
+
+    @Test
+    fun `build and parse uri types`() {
+        val uriRecord = NdefUtils.uriRecord("https://example.com")
+        val telRecord = NdefUtils.telRecord("12345")
+        val smsRecord = NdefUtils.smsRecord("12345", "hi")
+        val mailRecord = NdefUtils.mailRecord("a@b.com", subject = "s", body = "b")
+        val geoRecord = NdefUtils.geoRecord(1.0, 2.0)
+        val vcard = "BEGIN:VCARD\nVERSION:3.0\nEND:VCARD"
+        val vcardRecord = NdefUtils.vcardRecord(vcard)
+
+        assertEquals("URI", NdefUtils.parse(uriRecord).type)
+        assertEquals("TEL", NdefUtils.parse(telRecord).type)
+        assertEquals("SMS", NdefUtils.parse(smsRecord).type)
+        assertEquals("MAILTO", NdefUtils.parse(mailRecord).type)
+        assertEquals("GEO", NdefUtils.parse(geoRecord).type)
+        assertEquals("VCARD", NdefUtils.parse(vcardRecord).type)
+    }
+
+    @Test
+    fun `estimate size matches actual`() {
+        val records = listOf(
+            NdefUtils.textRecord("A"),
+            NdefUtils.uriRecord("https://example.com")
+        )
+        val estimate = NdefUtils.estimateSize(records)
+        val actual = NdefMessage(records.toTypedArray()).toByteArray().size
+        assertEquals(actual, estimate)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@ plugins {
   id("com.android.application") version "8.5.2" apply false
   id("org.jetbrains.kotlin.android") version "2.0.20" apply false
   id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
+  id("com.google.devtools.ksp") version "2.0.20-1.0.24" apply false
 }


### PR DESCRIPTION
## Summary
- configure Android module with Compose, Room, DataStore and Java 17
- add NDEF helpers for text, URI, telephone, SMS, mail, geo and vCard
- cover NDEF helpers with round-trip unit tests

## Testing
- `gradle :app:assembleDebug` *(fails: SDK location not found)*
- `gradle :app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11d21b85c8323b3f8909ec6f4757b