### PR TITLE
feat(app): basic NFC scaffold with Compose screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.0.2
+- Initial NFC reading and writing placeholders
+- Basic Compose navigation with read/write/settings screens

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,11 +14,17 @@
       </intent-filter>
 
       <!-- Optional: wake app on NDEF text/plain -->
-      <intent-filter>
-        <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <data android:mimeType="text/plain"/>
-      </intent-filter>
-    </activity>
-  </application>
-</manifest>
+        <intent-filter>
+          <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <data android:mimeType="text/plain"/>
+        </intent-filter>
+        <intent-filter>
+          <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <data android:scheme="http"/>
+          <data android:scheme="https"/>
+        </intent-filter>
+      </activity>
+    </application>
+  </manifest>

--- a/app/src/main/java/com/inskin/app/InskinNav.kt
+++ b/app/src/main/java/com/inskin/app/InskinNav.kt
@@ -1,79 +1,70 @@
 package com.inskin.app
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavHostController
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 
-sealed class Screen(val route: String, val label: String) {
-    object Read : Screen("read", "Lecture")
-    object Write : Screen("write", "Écriture")
-    object Settings : Screen("settings", "Paramètres")
-}
-
-/**
- * Navigation graph for the application. The currently scanned [tagInfo] is
- * passed down so the read screen can display it.
- */
 @Composable
-fun InskinNav(tagInfo: TagInfo? = null) {
+fun InskinNav(vm: NfcViewModel) {
     val navController = rememberNavController()
-    Scaffold(bottomBar = { BottomBar(navController) }) { padding ->
+    val items = listOf("read", "write", "settings")
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentRoute = navBackStackEntry?.destination?.route
+                items.forEach { route ->
+                    val icon = when (route) {
+                        "read" -> Icons.Default.Wifi
+                        "write" -> Icons.Default.Edit
+                        else -> Icons.Default.Settings
+                    }
+                    val label = when (route) {
+                        "read" -> stringResource(R.string.tab_read)
+                        "write" -> stringResource(R.string.tab_write)
+                        else -> stringResource(R.string.tab_settings)
+                    }
+                    NavigationBarItem(
+                        selected = currentRoute == route,
+                        onClick = {
+                            navController.navigate(route) {
+                                launchSingleTop = true
+                                restoreState = true
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                            }
+                        },
+                        icon = { Icon(icon, contentDescription = label) },
+                        label = { androidx.compose.material3.Text(label) }
+                    )
+                }
+            }
+        }
+    ) { padding ->
         NavHost(
             navController = navController,
-            startDestination = Screen.Read.route,
+            startDestination = "read",
             modifier = Modifier.padding(padding)
         ) {
-            composable(Screen.Read.route) { ReadScreen(tagInfo) }
-            composable(Screen.Write.route) { WriteScreen() }
-            composable(Screen.Settings.route) { SettingsScreen() }
+            composable("read") { ReadScreen(vm.tagInfo) }
+            composable("write") { WriteScreen(vm) }
+            composable("settings") { SettingsScreen() }
         }
     }
 }
-
-
-@Composable
-private fun BottomBar(navController: NavHostController) {
-    val items = listOf(Screen.Read, Screen.Write, Screen.Settings)
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
-
-    NavigationBar {
-        items.forEach { screen ->
-            val (icon, contentDesc) = when (screen) {
-                is Screen.Read -> Icons.Filled.Home to "Lecture"
-                is Screen.Write -> Icons.Filled.Create to "Écriture"
-                is Screen.Settings -> Icons.Filled.Settings to "Paramètres"
-            }
-            NavigationBarItem(
-                icon = { Icon(icon, contentDescription = contentDesc) },
-                label = { Text(screen.label) },
-                selected = currentRoute == screen.route,
-                onClick = {
-                    if (currentRoute != screen.route) {
-                        navController.navigate(screen.route) {
-                            popUpTo(navController.graph.startDestinationId) { saveState = true }
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    }
-                }
-            )
-        }
-    }
-}
-

--- a/app/src/main/java/com/inskin/app/InskinTheme.kt
+++ b/app/src/main/java/com/inskin/app/InskinTheme.kt
@@ -1,9 +1,18 @@
-﻿package com.inskin.app
+package com.inskin.app
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
+private val LightColors = lightColorScheme()
+private val DarkColors = darkColorScheme()
+
 @Composable
-fun InskinTheme(content: @Composable () -> Unit) {
-    MaterialTheme(content = content)
+fun InskinTheme(
+    darkTheme: Boolean = androidx.compose.foundation.isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(colorScheme = colors, content = content)
 }

--- a/app/src/main/java/com/inskin/app/MainActivity.kt
+++ b/app/src/main/java/com/inskin/app/MainActivity.kt
@@ -1,83 +1,40 @@
-﻿package com.inskin.app
+package com.inskin.app
 
 import android.nfc.NfcAdapter
 import android.nfc.Tag
-import android.nfc.tech.Ndef
-import android.nfc.tech.NfcA
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-
-// Assure-toi que ces imports pointent bien vers tes fichiers :
-import com.inskin.app.InskinTheme
-import com.inskin.app.InskinNav
+import androidx.activity.viewModels
 
 class MainActivity : ComponentActivity(), NfcAdapter.ReaderCallback {
-    private var nfcAdapter: NfcAdapter? = null
-
-    // Dernier tag scanné (observable par Compose)
-    private var tagInfo by mutableStateOf<TagInfo?>(null)
+    private val viewModel: NfcViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         setContent {
             InskinTheme {
-                // InskinNav doit accepter un paramètre optionnel: tagInfo: TagInfo? = null
-                InskinNav(tagInfo)
+                InskinNav(viewModel)
             }
         }
     }
 
     override fun onResume() {
         super.onResume()
-        nfcAdapter?.enableReaderMode(
+        NfcAdapter.getDefaultAdapter(this)?.enableReaderMode(
             this,
             this,
-            NfcAdapter.FLAG_READER_NFC_A or
-                NfcAdapter.FLAG_READER_NFC_B or
-                NfcAdapter.FLAG_READER_NFC_F or
-                NfcAdapter.FLAG_READER_NFC_V,
+            NfcAdapter.FLAG_READER_NFC_A or NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
             null
         )
     }
 
     override fun onPause() {
         super.onPause()
-        nfcAdapter?.disableReaderMode(this)
+        NfcAdapter.getDefaultAdapter(this)?.disableReaderMode(this)
     }
 
     override fun onTagDiscovered(tag: Tag) {
-        val id = tag.id.joinToString("") { "%02X".format(it) }
-        val techList = tag.techList.map { it.substringAfterLast('.') }
-
-        val nfcA = NfcA.get(tag)
-        val atqa = nfcA?.atqa?.joinToString("") { "%02X".format(it) } ?: "N/A"
-        val sak  = nfcA?.sak?.let { "0x%02X".format(it) } ?: "N/A"
-
-        val ndef = Ndef.get(tag)
-        val format = if (ndef != null) "NDEF" else "Inconnu"
-        val size = ndef?.maxSize ?: 0
-        val used = ndef?.cachedNdefMessage?.toByteArray()?.size ?: 0
-        val isWritable = ndef?.isWritable ?: false
-        val isReadOnly = ndef?.isWritable?.not() ?: false
-
-        val info = TagInfo(
-            type = techList.firstOrNull() ?: "Unknown",
-            tech = techList.joinToString(", "),
-            serial = id,
-            atqa = atqa,
-            sak = sak,
-            format = format,
-            size = size,
-            used = used,
-            isWritable = isWritable,
-            isReadOnly = isReadOnly
-        )
-
-        runOnUiThread { tagInfo = info }
+        viewModel.updateFromTag(tag)
     }
 }

--- a/app/src/main/java/com/inskin/app/NfcViewModel.kt
+++ b/app/src/main/java/com/inskin/app/NfcViewModel.kt
@@ -1,0 +1,69 @@
+package com.inskin.app
+
+import android.app.Application
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import androidx.lifecycle.AndroidViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.IOException
+
+/**
+ * ViewModel keeping track of the last NFC tag discovered and providing helpers
+ * to write NDEF messages.
+ */
+class NfcViewModel(application: Application) : AndroidViewModel(application) {
+    private var lastTag: Tag? = null
+
+    private val _tagInfo = MutableStateFlow<TagInfo?>(null)
+    val tagInfo = _tagInfo.asStateFlow()
+
+    fun updateFromTag(tag: Tag) {
+        lastTag = tag
+        val ndef = Ndef.get(tag)
+        val type = ndef?.type
+        val size = ndef?.maxSize ?: 0
+        val used = ndef?.cachedNdefMessage?.toByteArray()?.size ?: 0
+        val writable = ndef?.isWritable == true
+        val readonly = ndef?.isWritable == false
+        val uid = tag.id?.joinToString(separator = "") { b -> "%02X".format(b) }
+        val techs = tag.techList.toList()
+        _tagInfo.value = TagInfo(type, techs, uid, null, null, size, used, writable, readonly)
+    }
+
+    fun writeTextNdef(text: String): Result<Unit> = runCatching {
+        val tag = lastTag ?: error("No tag")
+        val ndef = Ndef.get(tag) ?: error("Tag is not NDEF")
+        ndef.connect()
+        val record = NdefRecord.createTextRecord("", text)
+        val message = NdefMessage(arrayOf(record))
+        ensureCapacity(ndef, message)
+        ndef.writeNdefMessage(message)
+        ndef.close()
+    }
+
+    fun writeUrlNdef(url: String): Result<Unit> = runCatching {
+        val tag = lastTag ?: error("No tag")
+        val ndef = Ndef.get(tag) ?: error("Tag is not NDEF")
+        ndef.connect()
+        val record = NdefRecord.createUri(url)
+        val message = NdefMessage(arrayOf(record))
+        ensureCapacity(ndef, message)
+        ndef.writeNdefMessage(message)
+        ndef.close()
+    }
+
+    private fun ensureCapacity(ndef: Ndef, message: NdefMessage) {
+        val bytes = message.toByteArray()
+        if (ndef.maxSize < bytes.size) {
+            ndef.close()
+            throw IOException("Tag capacity ${'$'}{ndef.maxSize} < ${'$'}{bytes.size}")
+        }
+        if (!ndef.isWritable) {
+            ndef.close()
+            throw IOException("Tag is read-only")
+        }
+    }
+}

--- a/app/src/main/java/com/inskin/app/ReadScreen.kt
+++ b/app/src/main/java/com/inskin/app/ReadScreen.kt
@@ -1,143 +1,89 @@
-﻿package com.inskin.app
-import androidx.compose.animation.core.animateFloat
+package com.inskin.app
 
-
-import androidx.compose.animation.core.FastOutSlowInEasing
+import android.content.Intent
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Nfc
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-/** Data about a scanned NFC tag. */
-data class TagInfo(
-    val type: String,
-    val tech: String,
-    val serial: String,
-    val atqa: String,
-    val sak: String,
-    val format: String,
-    val size: Int,
-    val used: Int,
-    val isWritable: Boolean,
-    val isReadOnly: Boolean
-)
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
-/**
- * Screen used to read an NFC tag. Displays waiting instructions when no tag is
- * scanned and shows details once one is detected.
- */
 @Composable
-fun ReadScreen(tagInfo: TagInfo? = null) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (tagInfo == null) {
-            val transition = rememberInfiniteTransition(label = "waiting")
-            val scale by transition.animateFloat(
-                initialValue = 1f,
-                targetValue = 1.2f,
-                animationSpec = infiniteRepeatable(
-                    tween(1000, easing = FastOutSlowInEasing),
-                    RepeatMode.Reverse
-                ),
-                label = "nfc_scale"
-            )
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("En attente d'un scan")
-                Icon(
-                    Icons.Filled.Nfc,
-                    contentDescription = "NFC",
-                    modifier = Modifier
-                        .padding(top = 16.dp)
-                        .size(120.dp)
-                        .scale(scale)
-                )
-            }
-        } else {
-            val scale by animateFloatAsState(
-                targetValue = 1.2f,
-                animationSpec = tween(durationMillis = 500),
-                label = "nfc_pulse"
-            )
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                Icon(
-                    Icons.Filled.Nfc,
-                    contentDescription = "NFC",
-                    modifier = Modifier
-                        .size(96.dp)
-                        .scale(scale)
-                )
-                Spacer(Modifier.height(16.dp))
-                InfoRow("Type de Tag", tagInfo.type)
-                InfoRow("Technologie disponible", tagInfo.tech)
-                InfoRow("NumÃ©ro de SÃ©rie", tagInfo.serial)
-                InfoRow("ATQA", tagInfo.atqa)
-                InfoRow("SAK", tagInfo.sak)
-                InfoRow("Format de donnÃ©es", tagInfo.format)
-                Spacer(Modifier.height(8.dp))
-                MemoryBar(tagInfo.size, tagInfo.used)
-                InfoRow("Taille", "${tagInfo.used}/${tagInfo.size} octets")
-                InfoRow("Ã‰criture Possible", if (tagInfo.isWritable) "Oui" else "Non")
-                InfoRow("Lecture Seule possible", if (tagInfo.isReadOnly) "Oui" else "Non")
+fun ReadScreen(tagInfoFlow: StateFlow<TagInfo?>) {
+    val tagInfo by tagInfoFlow.collectAsState()
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    if (tagInfo == null) {
+        val transition = rememberInfiniteTransition(label = "nfc")
+        val alpha by transition.animateFloat(
+            initialValue = 0.3f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(1000),
+                repeatMode = RepeatMode.Reverse
+            ), label = "alpha"
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(Icons.Default.Nfc, contentDescription = "nfc", modifier = Modifier.size(96.dp), tint = LocalContentColor.current.copy(alpha))
+            Spacer(Modifier.height(16.dp))
+            Text(text = stringResource(R.string.waiting_scan))
+        }
+    } else {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Text("UID: ${'$'}{tagInfo.uid}")
+            Text("Type: ${'$'}{tagInfo.type}")
+            Text("Size: ${'$'}{tagInfo.size}/${'$'}{tagInfo.used}")
+            Spacer(Modifier.height(16.dp))
+            Row {
+                Button(onClick = { clipboard.setText(AnnotatedString(tagInfo.uid ?: "")) }) {
+                    Text(stringResource(R.string.copy_uid))
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = {
+                    val send = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, tagInfo.uid)
+                    }
+                    context.startActivity(Intent.createChooser(send, null))
+                }) {
+                    Text(stringResource(R.string.share))
+                }
             }
         }
     }
 }
 
+@Preview
 @Composable
-private fun InfoRow(label: String, value: String) {
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
-        Text(text = "$label : ", fontWeight = FontWeight.Bold)
-        Text(text = value)
-    }
-}
-
-@Composable
-private fun MemoryBar(total: Int, used: Int) {
-    val progress = if (total > 0) used.toFloat() / total else 0f
-    LinearProgressIndicator(
-        progress = progress,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(8.dp)
-            .clip(RoundedCornerShape(4.dp))
-    )
+private fun PreviewWaiting() {
+    val flow = MutableStateFlow<TagInfo?>(null)
+    ReadScreen(flow)
 }
 
 @Preview
 @Composable
-fun ReadScreenPreview() {
-    ReadScreen(
-        tagInfo = TagInfo(
-            type = "MIFARE Ultralight",
-            tech = "NFC-A",
-            serial = "04A224B12C34",
-            atqa = "0x4400",
-            sak = "0x00",
-            format = "NDEF",
-            size = 144,
-            used = 32,
-            isWritable = true,
-            isReadOnly = false
-        )
-    )
+private fun PreviewWithTag() {
+    val info = TagInfo("NDEF", listOf("android.nfc.tech.Ndef"), "DEADBEEF", null, null, 1024, 128, true, false)
+    val flow = MutableStateFlow<TagInfo?>(info)
+    ReadScreen(flow)
 }

--- a/app/src/main/java/com/inskin/app/SettingsScreen.kt
+++ b/app/src/main/java/com/inskin/app/SettingsScreen.kt
@@ -1,9 +1,35 @@
-﻿package com.inskin.app
+package com.inskin.app
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SettingsScreen() {
-  Text("ParamÃ¨tres")
+    val context = LocalContext.current
+    var dark by remember { mutableStateOf(true) }
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(stringResource(R.string.tab_settings))
+        Switch(checked = dark, onCheckedChange = { dark = it })
+        Button(onClick = {
+            val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:inskin@example.com"))
+            context.startActivity(intent)
+        }) { Text(stringResource(R.string.send_feedback)) }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSettings() {
+    SettingsScreen()
 }

--- a/app/src/main/java/com/inskin/app/TagInfo.kt
+++ b/app/src/main/java/com/inskin/app/TagInfo.kt
@@ -1,0 +1,16 @@
+package com.inskin.app
+
+/**
+ * Holds details about a discovered NFC tag.
+ */
+data class TagInfo(
+    val type: String?,
+    val techs: List<String>,
+    val uid: String?,
+    val atqa: String?,
+    val sak: String?,
+    val size: Int,
+    val used: Int,
+    val writable: Boolean,
+    val readonly: Boolean,
+)

--- a/app/src/main/java/com/inskin/app/WriteScreen.kt
+++ b/app/src/main/java/com/inskin/app/WriteScreen.kt
@@ -1,9 +1,48 @@
-﻿package com.inskin.app
+package com.inskin.app
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.TextField
+import androidx.compose.material3.rememberSnackbarHostState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collectAsState
+import kotlinx.coroutines.launch
 
 @Composable
-fun WriteScreen() {
-  Text("Ã‰cran Ã‰criture â€“ NFC Ã  intÃ©grer ici")
+fun WriteScreen(vm: NfcViewModel) {
+    val snackbarHostState = rememberSnackbarHostState()
+    val scope = rememberCoroutineScope()
+    var text by remember { mutableStateOf("") }
+    var url by remember { mutableStateOf("") }
+    val tagInfo by vm.tagInfo.collectAsState()
+    Column(modifier = Modifier.padding(16.dp)) {
+        TextField(value = text, onValueChange = { text = it }, label = { Text(stringResource(R.string.write_text_hint)) })
+        TextField(value = url, onValueChange = { url = it }, label = { Text(stringResource(R.string.write_url_hint)) })
+        Button(
+            onClick = {
+                val result = if (url.isNotBlank()) vm.writeUrlNdef(url) else vm.writeTextNdef(text)
+                scope.launch {
+                    val msg = result.fold({ stringResource(R.string.write_success) }, { it.message ?: "error" })
+                    snackbarHostState.showSnackbar(msg)
+                }
+            },
+            enabled = tagInfo != null
+        ) { Text(stringResource(R.string.btn_write)) }
+        SnackbarHost(hostState = snackbarHostState)
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewWrite() {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    WriteScreen(vm = NfcViewModel(context.applicationContext as android.app.Application))
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,14 @@
 <resources>
-  <string name="app_name">Inskin</string>
+    <string name="app_name">Inskin</string>
+    <string name="tab_read">Read</string>
+    <string name="tab_write">Write</string>
+    <string name="tab_settings">Settings</string>
+    <string name="waiting_scan">Waiting for tag…</string>
+    <string name="btn_write">Write to tag</string>
+    <string name="write_text_hint">Text NDEF</string>
+    <string name="write_url_hint">URL NDEF</string>
+    <string name="write_success">Write ok</string>
+    <string name="copy_uid">Copy UID</string>
+    <string name="share">Share</string>
+    <string name="send_feedback">Send feedback</string>
 </resources>


### PR DESCRIPTION
## Summary
- add tag info data model and NFC view model with read/write helpers
- introduce Compose navigation with read, write, and settings screens
- wire MainActivity for NFC reader mode and add manifest intent filters

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bcdcb6f483238b3b236a86bfaf66