### PR TITLE
Add basic write item model and UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@
   id("org.jetbrains.kotlin.android")
   id("org.jetbrains.kotlin.plugin.compose")
   id("com.google.devtools.ksp")
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {

--- a/app/src/main/java/com/inskin/app/NfcViewModel.kt
+++ b/app/src/main/java/com/inskin/app/NfcViewModel.kt
@@ -1,13 +1,17 @@
 package com.inskin.app
 
 import android.app.Application
+import android.net.Uri
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import android.nfc.Tag
 import android.nfc.tech.Ndef
 import androidx.lifecycle.AndroidViewModel
+import com.inskin.app.model.WriteItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.IOException
 
 /**
@@ -33,23 +37,61 @@ class NfcViewModel(application: Application) : AndroidViewModel(application) {
         _tagInfo.value = TagInfo(type, techs, uid, null, null, size, used, writable, readonly)
     }
 
-    fun writeTextNdef(text: String): Result<Unit> = runCatching {
-        val tag = lastTag ?: error("No tag")
-        val ndef = Ndef.get(tag) ?: error("Tag is not NDEF")
-        ndef.connect()
-        val record = NdefRecord.createTextRecord("", text)
-        val message = NdefMessage(arrayOf(record))
-        ensureCapacity(ndef, message)
-        ndef.writeNdefMessage(message)
-        ndef.close()
+    /** Build an [NdefMessage] from a list of [WriteItem]. */
+    fun buildNdefMessage(items: List<WriteItem>): NdefMessage {
+        val records = items.map { item ->
+            when (item) {
+                is WriteItem.Text -> NdefRecord.createTextRecord("", item.text)
+                is WriteItem.Url -> NdefRecord.createUri(item.url)
+                is WriteItem.UriItem -> NdefRecord.createUri(item.uri)
+                is WriteItem.Phone -> NdefRecord.createUri("tel:${item.number}")
+                is WriteItem.Sms -> {
+                    val body = item.body?.let { "?body=" + Uri.encode(it) } ?: ""
+                    NdefRecord.createUri("sms:${item.number}${body}")
+                }
+                is WriteItem.Mail -> {
+                    val params = buildList {
+                        item.subject?.let { add("subject=${Uri.encode(it)}") }
+                        item.body?.let { add("body=${Uri.encode(it)}") }
+                    }
+                    val uri = buildString {
+                        append("mailto:${item.to}")
+                        if (params.isNotEmpty()) append("?").append(params.joinToString("&"))
+                    }
+                    NdefRecord.createUri(uri)
+                }
+                is WriteItem.Wifi -> {
+                    val password = item.password ?: ""
+                    NdefRecord.createUri("WIFI:S:${item.ssid};T:${item.security};P:${password};;")
+                }
+                is WriteItem.Bluetooth -> NdefRecord.createUri("BT:${item.mac}")
+                is WriteItem.Contact -> {
+                    val vcard = buildString {
+                        appendLine("BEGIN:VCARD")
+                        appendLine("VERSION:3.0")
+                        appendLine("FN:${item.name}")
+                        item.phone?.let { appendLine("TEL:$it") }
+                        item.email?.let { appendLine("EMAIL:$it") }
+                        appendLine("END:VCARD")
+                    }
+                    NdefRecord.createMime("text/vcard", vcard.toByteArray())
+                }
+                is WriteItem.Location -> NdefRecord.createUri("geo:${item.lat},${item.lon}")
+                is WriteItem.Data -> {
+                    val json = Json.encodeToString(mapOf(item.key to item.value))
+                    NdefRecord.createMime("application/x-inskin", json.toByteArray())
+                }
+            }
+        }
+        return NdefMessage(records.toTypedArray())
     }
 
-    fun writeUrlNdef(url: String): Result<Unit> = runCatching {
+    /** Write a list of items to the last seen tag. */
+    fun writeItems(items: List<WriteItem>): Result<Unit> = runCatching {
         val tag = lastTag ?: error("No tag")
         val ndef = Ndef.get(tag) ?: error("Tag is not NDEF")
         ndef.connect()
-        val record = NdefRecord.createUri(url)
-        val message = NdefMessage(arrayOf(record))
+        val message = buildNdefMessage(items)
         ensureCapacity(ndef, message)
         ndef.writeNdefMessage(message)
         ndef.close()

--- a/app/src/main/java/com/inskin/app/WriteFormSheets.kt
+++ b/app/src/main/java/com/inskin/app/WriteFormSheets.kt
@@ -1,0 +1,84 @@
+package com.inskin.app
+
+import android.util.Patterns
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.inskin.app.model.WriteItem
+import com.inskin.app.model.WriteItemType
+
+/**
+ * Content of the second bottom sheet used to enter a WriteItem payload.
+ */
+@Composable
+fun WriteItemForm(type: WriteItemType, onSubmit: (WriteItem) -> Unit) {
+    when (type) {
+        WriteItemType.TEXT -> TextItemForm { onSubmit(it) }
+        WriteItemType.URL -> UrlItemForm { onSubmit(it) }
+        else -> Column(Modifier.padding(16.dp)) { Text(stringResource(R.string.not_implemented)) }
+    }
+}
+
+@Composable
+private fun TextItemForm(onSubmit: (WriteItem.Text) -> Unit) {
+    var text by remember { mutableStateOf("") }
+    Column(Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            label = { Text(stringResource(R.string.write_text_hint)) },
+            singleLine = true,
+            isError = text.isBlank()
+        )
+        Button(
+            onClick = { if (text.isNotBlank()) onSubmit(WriteItem.Text(text)) },
+            enabled = text.isNotBlank(),
+            modifier = Modifier.padding(top = 16.dp)
+        ) { Text(stringResource(R.string.action_add)) }
+    }
+}
+
+@Composable
+private fun UrlItemForm(onSubmit: (WriteItem.Url) -> Unit) {
+    var url by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf(false) }
+    Column(Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = url,
+            onValueChange = {
+                url = it
+                error = it.isNotBlank() && !Patterns.WEB_URL.matcher(it).matches()
+            },
+            label = { Text(stringResource(R.string.write_url_hint)) },
+            singleLine = true,
+            isError = error,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+        )
+        Button(
+            onClick = { if (!error && url.isNotBlank()) onSubmit(WriteItem.Url(url)) },
+            enabled = url.isNotBlank() && !error,
+            modifier = Modifier.padding(top = 16.dp)
+        ) { Text(stringResource(R.string.action_add)) }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewTextForm() {
+    WriteItemForm(WriteItemType.TEXT) { }
+}
+
+@Preview
+@Composable
+private fun PreviewUrlForm() {
+    WriteItemForm(WriteItemType.URL) { }
+}

--- a/app/src/main/java/com/inskin/app/WriteScreen.kt
+++ b/app/src/main/java/com/inskin/app/WriteScreen.kt
@@ -1,48 +1,158 @@
 package com.inskin.app
 
+import android.content.Context
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Article
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Link
 import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.rememberSnackbarHostState
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.inskin.app.model.WriteItem
+import com.inskin.app.model.WriteItemType
 import kotlinx.coroutines.flow.collectAsState
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
+private val Context.writeDataStore by preferencesDataStore("write_items")
+private val WRITE_ITEMS_KEY = stringPreferencesKey("write_items_json")
+
+/**
+ * Main screen for creating a list of [WriteItem] and writing them to a tag.
+ */
 @Composable
 fun WriteScreen(vm: NfcViewModel) {
-    val snackbarHostState = rememberSnackbarHostState()
+    val context = LocalContext.current
+    val dataStore = context.writeDataStore
     val scope = rememberCoroutineScope()
-    var text by remember { mutableStateOf("") }
-    var url by remember { mutableStateOf("") }
+    val snackbarHostState: SnackbarHostState = rememberSnackbarHostState()
+    var items by remember { mutableStateOf<List<WriteItem>>(emptyList()) }
+    val json = Json
+
+    LaunchedEffect(Unit) {
+        val stored = dataStore.data.first()[WRITE_ITEMS_KEY]
+        stored?.let { items = json.decodeFromString(it) }
+    }
+    LaunchedEffect(items) {
+        dataStore.edit { it[WRITE_ITEMS_KEY] = json.encodeToString(items) }
+    }
+
     val tagInfo by vm.tagInfo.collectAsState()
-    Column(modifier = Modifier.padding(16.dp)) {
-        TextField(value = text, onValueChange = { text = it }, label = { Text(stringResource(R.string.write_text_hint)) })
-        TextField(value = url, onValueChange = { url = it }, label = { Text(stringResource(R.string.write_url_hint)) })
-        Button(
-            onClick = {
-                val result = if (url.isNotBlank()) vm.writeUrlNdef(url) else vm.writeTextNdef(text)
-                scope.launch {
-                    val msg = result.fold({ stringResource(R.string.write_success) }, { it.message ?: "error" })
-                    snackbarHostState.showSnackbar(msg)
+    var showTypeSheet by remember { mutableStateOf(false) }
+    var formType by remember { mutableStateOf<WriteItemType?>(null) }
+
+    if (showTypeSheet) {
+        ModalBottomSheet(onDismissRequest = { showTypeSheet = false }) {
+            ListItem(
+                leadingContent = { Icon(Icons.Filled.Article, contentDescription = null) },
+                headlineText = { Text(stringResource(R.string.action_text)) },
+                modifier = Modifier.clickable {
+                    showTypeSheet = false
+                    formType = WriteItemType.TEXT
                 }
-            },
-            enabled = tagInfo != null
-        ) { Text(stringResource(R.string.btn_write)) }
-        SnackbarHost(hostState = snackbarHostState)
+            )
+            ListItem(
+                leadingContent = { Icon(Icons.Filled.Link, contentDescription = null) },
+                headlineText = { Text(stringResource(R.string.action_url)) },
+                modifier = Modifier.clickable {
+                    showTypeSheet = false
+                    formType = WriteItemType.URL
+                }
+            )
+        }
+    }
+
+    if (formType != null) {
+        ModalBottomSheet(onDismissRequest = { formType = null }) {
+            WriteItemForm(formType!!) { item ->
+                items = items + item
+                formType = null
+            }
+        }
+    }
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showTypeSheet = true }) {
+                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.write_add_item))
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+            LazyColumn(modifier = Modifier.weight(1f, true)) {
+                itemsIndexed(items) { index, item ->
+                    ListItem(
+                        leadingContent = {
+                            when (item.type) {
+                                WriteItemType.TEXT -> Icon(Icons.Filled.Article, contentDescription = null)
+                                WriteItemType.URL -> Icon(Icons.Filled.Link, contentDescription = null)
+                                else -> Icon(Icons.Filled.Article, contentDescription = null)
+                            }
+                        },
+                        headlineText = {
+                            when (item) {
+                                is WriteItem.Text -> Text(item.text)
+                                is WriteItem.Url -> Text(item.url)
+                                else -> Text(item.type.name)
+                            }
+                        },
+                        trailingContent = {
+                            IconButton(onClick = {
+                                items = items.toMutableList().also { it.removeAt(index) }
+                            }) {
+                                Icon(Icons.Filled.Delete, contentDescription = null)
+                            }
+                        }
+                    )
+                }
+            }
+            Button(
+                onClick = {
+                    val result = vm.writeItems(items)
+                    scope.launch {
+                        val msg = result.fold({ stringResource(R.string.write_success) }, { it.message ?: "error" })
+                        snackbarHostState.showSnackbar(msg)
+                    }
+                },
+                enabled = tagInfo != null && items.isNotEmpty(),
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) { Text(stringResource(R.string.btn_write)) }
+        }
     }
 }
 
 @Preview
 @Composable
 private fun PreviewWrite() {
-    val context = androidx.compose.ui.platform.LocalContext.current
+    val context = LocalContext.current
     WriteScreen(vm = NfcViewModel(context.applicationContext as android.app.Application))
 }

--- a/app/src/main/java/com/inskin/app/model/WriteItem.kt
+++ b/app/src/main/java/com/inskin/app/model/WriteItem.kt
@@ -1,0 +1,109 @@
+package com.inskin.app.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Types of items that can be written to an NFC tag.
+ */
+@Serializable
+enum class WriteItemType {
+    TEXT,
+    URL,
+    WEB_SEARCH,
+    SOCIAL,
+    VIDEO,
+    FILE,
+    APP,
+    MAIL,
+    CONTACT,
+    PHONE,
+    SMS,
+    LOCATION,
+    CUSTOM_LOCATION,
+    ADDRESS,
+    DESTINATION,
+    NEARBY_SEARCH,
+    STREET_VIEW,
+    EMERGENCY,
+    CRYPTO,
+    BLUETOOTH,
+    WIFI,
+    CUSTOM_DATA,
+    SETTINGS,
+    CONDITION
+}
+
+/**
+ * Sealed hierarchy representing an item to write.
+ * Only a small subset is currently used by the UI but the model allows more
+ * types to be added later.
+ */
+@Serializable
+sealed class WriteItem {
+    abstract val type: WriteItemType
+
+    /** Plain text payload. */
+    @Serializable
+    data class Text(val text: String) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.TEXT
+    }
+
+    /** Web or application URL. */
+    @Serializable
+    data class Url(val url: String) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.URL
+    }
+
+    /** Phone number. */
+    @Serializable
+    data class Phone(val number: String) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.PHONE
+    }
+
+    /** SMS payload with optional body. */
+    @Serializable
+    data class Sms(val number: String, val body: String? = null) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.SMS
+    }
+
+    /** Email payload. */
+    @Serializable
+    data class Mail(val to: String, val subject: String? = null, val body: String? = null) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.MAIL
+    }
+
+    /** Wi‑Fi network information. */
+    @Serializable
+    data class Wifi(val ssid: String, val security: String, val password: String? = null) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.WIFI
+    }
+
+    /** Bluetooth MAC address. */
+    @Serializable
+    data class Bluetooth(val mac: String) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.BLUETOOTH
+    }
+
+    /** Minimal contact information. */
+    @Serializable
+    data class Contact(val name: String, val phone: String? = null, val email: String? = null) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.CONTACT
+    }
+
+    /** Geographic coordinates. */
+    @Serializable
+    data class Location(val lat: Double, val lon: Double) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.LOCATION
+    }
+
+    /** Generic key/value pair serialised as custom data. */
+    @Serializable
+    data class Data(val key: String, val value: String) : WriteItem() {
+        override val type: WriteItemType = WriteItemType.CUSTOM_DATA
+    }
+
+    /** Generic URI based item for less common types. */
+    @Serializable
+    data class UriItem(override val type: WriteItemType, val uri: String) : WriteItem()
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,9 @@
     <string name="copy_uid">Copy UID</string>
     <string name="share">Share</string>
     <string name="send_feedback">Send feedback</string>
+    <string name="action_text">Text</string>
+    <string name="action_url">URL</string>
+    <string name="action_add">Add</string>
+    <string name="write_add_item">Add item</string>
+    <string name="not_implemented">Not implemented yet</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
   id("org.jetbrains.kotlin.android") version "2.0.20" apply false
   id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
   id("com.google.devtools.ksp") version "2.0.20-1.0.24" apply false
+  id("org.jetbrains.kotlin.plugin.serialization") version "2.0.20" apply false
 }


### PR DESCRIPTION
## Summary
- add serializable WriteItem model to represent NFC payloads
- support adding Text and URL items with bottom-sheet forms and persistence
- build NDEF messages from WriteItem list and write to tag

## Testing
- `gradle :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf01de308323b5d3d6386c879372