### PR TITLE
Refactor tag utilities and improve validation

### DIFF
--- a/inskin/__init__.py
+++ b/inskin/__init__.py
@@ -4,7 +4,10 @@ Inskin core module.
 Provides basic placeholder functions to read and write NFC/RFID tags.
 """
 
+"""Public API for the :mod:`inskin` package."""
+
+from .tag import Tag
 from .reader import read_tag
 from .writer import write_tag
 
-__all__ = ["read_tag", "write_tag"]
+__all__ = ["Tag", "read_tag", "write_tag"]

--- a/inskin/reader.py
+++ b/inskin/reader.py
@@ -1,8 +1,10 @@
 """Reader utilities for Inskin.
 
-These functions are placeholders for actual NFC/RFID reader interactions.
-"""
+These functions are placeholders for actual NFC/RFID reader interactions."""
 
-def read_tag():
-    """Return mock data representing a scanned tag."""
-    return {"uid": "DEADBEEF", "type": "placeholder"}
+from .tag import Tag
+
+
+def read_tag() -> Tag:
+    """Return mock data representing a scanned :class:`Tag`."""
+    return Tag(uid="DEADBEEF", type="placeholder")

--- a/inskin/tag.py
+++ b/inskin/tag.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+@dataclass
+class Tag:
+    """Simple representation of an NFC/RFID tag."""
+    uid: str
+    type: str

--- a/inskin/writer.py
+++ b/inskin/writer.py
@@ -1,8 +1,20 @@
 """Writer utilities for Inskin.
 
-These functions are placeholders for actual NFC/RFID writer interactions.
-"""
+These functions are placeholders for actual NFC/RFID writer interactions."""
 
-def write_tag(data):
-    """Mock writing data to a tag by printing the payload."""
-    print(f"Writing data to tag: {data}")
+from typing import Any, Mapping
+
+
+def write_tag(data: Mapping[str, Any]) -> None:
+    """Mock writing data to a tag by printing the payload.
+
+    Parameters
+    ----------
+    data:
+        Mapping containing the information to write. Must be a mapping; a
+        :class:`TypeError` is raised otherwise.
+    """
+    if not isinstance(data, Mapping):
+        raise TypeError("data must be a mapping")
+
+    print(f"Writing data to tag: {dict(data)}")

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 """Command-line interface for the Inskin placeholder application."""
 
-from inskin import read_tag, write_tag
+from inskin import Tag, read_tag, write_tag
 
 
 def main():
     """Demonstrate reading and writing tag operations."""
     tag = read_tag()
-    print("Read tag:", tag)
+    print(f"Read tag: {tag.uid} ({tag.type})")
     write_tag({"text": "Hello from Inskin"})
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,19 @@
-from inskin import read_tag
+import pytest
+
+from inskin import Tag, read_tag, write_tag
 
 
 def test_read_tag_returns_mock_data():
     tag = read_tag()
-    assert tag["uid"] == "DEADBEEF"
+    assert isinstance(tag, Tag)
+    assert tag.uid == "DEADBEEF"
+
+
+def test_write_tag_validates_input(capsys):
+    payload = {"text": "hello"}
+    write_tag(payload)
+    captured = capsys.readouterr()
+    assert "Writing data to tag: {'text': 'hello'}" in captured.out
+
+    with pytest.raises(TypeError):
+        write_tag("not a mapping")


### PR DESCRIPTION
## Summary
- Introduce `Tag` dataclass and export it in package API
- Return `Tag` objects from `read_tag`
- Validate mapping input for `write_tag` and add tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3468a305c832396f86fadcdd1f582